### PR TITLE
NUMBERS-40: Review exception usage in package "o.a.c.numbers.gamma"

### DIFF
--- a/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/GammaException.java
+++ b/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/GammaException.java
@@ -21,7 +21,7 @@ import java.text.MessageFormat;
 /**
  * Package private exception class with constants for frequently used messages.
  */
-class GammaException extends IllegalArgumentException {
+class GammaException extends ArithmeticException {
     /** Error message for "out of range" condition. */
     static final String OUT_OF_RANGE = "Number {0} is out of range [{1}, {2}]";
     /** Error message for convergence failure. */

--- a/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/InvGamma1pm1.java
+++ b/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/InvGamma1pm1.java
@@ -106,7 +106,7 @@ class InvGamma1pm1 {
      *
      * @param x Argument.
      * @return \( \frac{1}{\Gamma(1 + x)} - 1 \)
-     * @throws IllegalArgumentException if {@code x < -0.5} or {@code x > 1.5}
+     * @throws GammaException if {@code x < -0.5} or {@code x > 1.5}
      */
     public static double value(final double x) {
         if (x < -0.5 || x > 1.5) {

--- a/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogBeta.java
+++ b/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogBeta.java
@@ -71,8 +71,8 @@ public class LogBeta {
      * @param a First argument.
      * @param b Second argument.
      * @return the value of {@code Delta(b) - Delta(a + b)}
-     * @throws IllegalArgumentException if {@code a < 0} or {@code a > b}
-     * @throws IllegalArgumentException if {@code b < 10}
+     * @throws GammaException if {@code a < 0} or {@code a > b}
+     * @throws GammaException if {@code b < 10}
      */
     private static double deltaMinusDeltaSum(final double a,
                                              final double b) {
@@ -116,7 +116,7 @@ public class LogBeta {
      * @param p First argument.
      * @param q Second argument.
      * @return the value of {@code Delta(p) + Delta(q) - Delta(p + q)}.
-     * @throws IllegalArgumentException if {@code p < 10} or {@code q < 10}.
+     * @throws GammaException if {@code p < 10} or {@code q < 10}.
      */
     private static double sumDeltaMinusDeltaSum(final double p,
                                                 final double q) {

--- a/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogGamma1p.java
+++ b/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogGamma1p.java
@@ -30,7 +30,7 @@ class LogGamma1p {
      *
      * @param x Argument.
      * @return \( \ln \Gamma(1 + x) \)
-     * @throws IllegalArgumentException if {@code x < -0.5} or {@code x > 1.5}.
+     * @throws GammaException if {@code x < -0.5} or {@code x > 1.5}.
      */
     public static double value(final double x) {
         if (x < -0.5 || x > 1.5) {

--- a/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogGammaSum.java
+++ b/commons-numbers-gamma/src/main/java/org/apache/commons/numbers/gamma/LogGammaSum.java
@@ -31,7 +31,7 @@ class LogGammaSum {
      * @param a First argument.
      * @param b Second argument.
      * @return the value of {@code log(Gamma(a + b))}.
-     * @throws IllegalArgumentException if {@code a} or {@code b} is lower than 1
+     * @throws GammaException if {@code a} or {@code b} is lower than 1
      * or larger than 2.
      */
     static double value(double a,

--- a/commons-numbers-gamma/src/test/java/org/apache/commons/numbers/gamma/LogBetaTest.java
+++ b/commons-numbers-gamma/src/test/java/org/apache/commons/numbers/gamma/LogBetaTest.java
@@ -506,12 +506,12 @@ public class LogBetaTest {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaMinusLogGammaSumPrecondition1() {
         logGammaMinusLogGammaSum(-1, 8);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaMinusLogGammaSumPrecondition2() {
         logGammaMinusLogGammaSum(1, 7);
     }
@@ -682,12 +682,12 @@ public class LogBetaTest {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testSumDeltaMinusDeltaSumPrecondition1() {
         sumDeltaMinusDeltaSum(9, 10);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testSumDeltaMinusDeltaSumPrecondition2() {
         sumDeltaMinusDeltaSum(10, 9);
     }

--- a/commons-numbers-gamma/src/test/java/org/apache/commons/numbers/gamma/LogGammaSumTest.java
+++ b/commons-numbers-gamma/src/test/java/org/apache/commons/numbers/gamma/LogGammaSumTest.java
@@ -144,22 +144,22 @@ public class LogGammaSumTest {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaSumPrecondition1() {
         LogGammaSum.value(0, 1);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaSumPrecondition2() {
         LogGammaSum.value(3, 1);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaSumPrecondition3() {
         LogGammaSum.value(1, 0);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=GammaException.class)
     public void testLogGammaSumPrecondition4() {
         LogGammaSum.value(1, 3);
     }


### PR DESCRIPTION
Modified "GammaException" to be a subclass of "ArithmeticException" instead of "IllegalArgumentException".
Modified the test assertions to expect for "GammaException"s instead of "IllegalArgumentException"s.