### PR TITLE
NUMBERS-84: Checks for NaN and Infinite in Quaternion Normalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ language: java
 sudo: false
 
 jdk:
-  - openjdk7
   - oraclejdk8
 
 after_success:

--- a/commons-numbers-quaternion/src/main/java/org/apache/commons/numbers/quaternion/Quaternion.java
+++ b/commons-numbers-quaternion/src/main/java/org/apache/commons/numbers/quaternion/Quaternion.java
@@ -42,7 +42,7 @@ public abstract class Quaternion implements Serializable {
     /** Serializable version identifier. */
     private static final long serialVersionUID = 20170118L;
     /** Error message. */
-    private static final String ZERO_NORM_MSG = "Norm is zero";
+    private static final String ILLEGAL_NORM_MSG = "Illegal norm: ";
 
     /** {@link #toString() String representation}. */
     private static final String FORMAT_START = "[";
@@ -274,13 +274,14 @@ public abstract class Quaternion implements Serializable {
      * The norm of the quaternion must not be near zero.
      *
      * @return a normalized quaternion.
-     * @throws IllegalStateException if the norm of the quaternion is near zero.
+     * @throws IllegalStateException if the norm of the quaternion is NaN, infinite,
+     *      or near zero
      */
     public Quaternion normalize() {
         final double norm = norm();
 
-        if (norm < Precision.SAFE_MIN) {
-            throw new IllegalStateException(ZERO_NORM_MSG);
+        if (!Double.isFinite(norm) || norm < Precision.SAFE_MIN) {
+            throw new IllegalStateException(ILLEGAL_NORM_MSG + norm);
         }
 
         final Quaternion unit = divide(norm);
@@ -389,12 +390,13 @@ public abstract class Quaternion implements Serializable {
      * The norm of the quaternion must not be zero.
      *
      * @return the inverse.
-     * @throws IllegalArgumentException if the norm (squared) of the quaternion is zero.
+     * @throws IllegalStateException if the norm (squared) of the quaternion is NaN, infinite,
+     *      or near zero
      */
     public Quaternion inverse() {
         final double squareNorm = normSq();
-        if (squareNorm < Precision.SAFE_MIN) {
-            throw new IllegalStateException(ZERO_NORM_MSG);
+        if (!Double.isFinite(squareNorm) || squareNorm < Precision.SAFE_MIN) {
+            throw new IllegalStateException(ILLEGAL_NORM_MSG + Math.sqrt(squareNorm));
         }
 
         return of(w / squareNorm,

--- a/commons-numbers-quaternion/src/test/java/org/apache/commons/numbers/quaternion/QuaternionTest.java
+++ b/commons-numbers-quaternion/src/test/java/org/apache/commons/numbers/quaternion/QuaternionTest.java
@@ -332,8 +332,26 @@ public class QuaternionTest {
     }
 
     @Test(expected=IllegalStateException.class)
-    public final void testNormalizeFail() {
+    public final void testNormalizeFail_zero() {
         final Quaternion zeroQ = Quaternion.of(0, 0, 0, 0);
+        zeroQ.normalize();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public final void testNormalizeFail_nan() {
+        final Quaternion zeroQ = Quaternion.of(0, 0, 0, Double.NaN);
+        zeroQ.normalize();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public final void testNormalizeFail_positiveInfinity() {
+        final Quaternion zeroQ = Quaternion.of(0, 0, Double.POSITIVE_INFINITY, 0);
+        zeroQ.normalize();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public final void testNormalizeFail_negativeInfinity() {
+        final Quaternion zeroQ = Quaternion.of(0, Double.NEGATIVE_INFINITY, 0, 0);
         zeroQ.normalize();
     }
 
@@ -538,6 +556,30 @@ public class QuaternionTest {
         } catch (IllegalStateException ex) {
             // expected
         }
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testInverse_zeroNorm() {
+        Quaternion q = Quaternion.of(0, 0, 0, 0);
+        q.inverse();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testInverse_nanNorm() {
+        Quaternion q = Quaternion.of(Double.NaN, 0, 0, 0);
+        q.inverse();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testInverse_positiveInfinityNorm() {
+        Quaternion q = Quaternion.of(0, Double.POSITIVE_INFINITY, 0, 0);
+        q.inverse();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testInverse_negativeInfinityNorm() {
+        Quaternion q = Quaternion.of(0, 0, Double.NEGATIVE_INFINITY, 0);
+        q.inverse();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,8 @@
     <commons.jira.id>NUMBERS</commons.jira.id>
     <commons.jira.pid>12320720</commons.jira.pid>
     <commons.encoding>UTF-8</commons.encoding>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <numbers.pmd.version>3.9.0</numbers.pmd.version>
     <numbers.checkstyle.version>3.0.0</numbers.checkstyle.version>
     <numbers.mathjax.version>2.7.2</numbers.mathjax.version>


### PR DESCRIPTION
Adding NaN and infinite checks to Quaternion.normalize() and Quaternion.inverse(). I ended up bumping the JDK version from 6 to 8 in order to use Double.isFinite(). If this causes issues, I can rework it.