### PR TITLE
Numbers 93: PlaneAngle normalize() upper bound is exclusive

### DIFF
--- a/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngle.java
+++ b/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngle.java
@@ -91,7 +91,7 @@ public class PlaneAngle {
      *
      * @param center Center of the desired interval for the result.
      * @return {@code a - k} with integer {@code k} such that
-     * {@code center - 0.5 <= a - k <= center + 0.5} (in turns).
+     * {@code center - 0.5 <= a - k < center + 0.5} (in turns).
      */
     public PlaneAngle normalize(PlaneAngle center) {
         return new PlaneAngle(value - Math.floor(value + HALF_TURN - center.value));

--- a/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngleRadians.java
+++ b/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngleRadians.java
@@ -33,7 +33,7 @@ public class PlaneAngleRadians {
      * @param angle Value to be normalized.
      * @param center Center of the desired interval for the result.
      * @return {@code a - 2 * k} with integer {@code k} such that
-     * {@code center - pi <= a - 2 * k * pi <= center + pi}.
+     * {@code center - pi <= a - 2 * k * pi < center + pi}.
      */
     public static double normalize(double angle,
                                    double center) {
@@ -43,22 +43,22 @@ public class PlaneAngleRadians {
     }
 
     /**
-     * Normalize an angle between -&pi; and &pi;.
+     * Normalize an angle to be in the range [-&pi;, &pi;).
      *
      * @param angle Value to be normalized.
      * @return {@code a - 2 * k} with integer {@code k} such that
-     * {@code -pi <= a - 2 * k * pi <= pi}.
+     * {@code -pi <= a - 2 * k * pi < pi}.
      */
     public static double normalizeBetweenMinusPiAndPi(double angle) {
         return PlaneAngle.ofRadians(angle).normalize(PlaneAngle.ZERO).toRadians();
     }
 
     /**
-     * Normalize an angle between 0 and 2&pi;.
+     * Normalize an angle to be in the range [0, 2&pi;).
      *
      * @param angle Value to be normalized.
      * @return {@code a - 2 * k} with integer {@code k} such that
-     * {@code 0 <= a - 2 * k * pi <= 2 * pi}.
+     * {@code 0 <= a - 2 * k * pi < 2 * pi}.
      */
     public static double normalizeBetweenZeroAndTwoPi(double angle) {
         return PlaneAngle.ofRadians(angle).normalize(PlaneAngle.PI).toRadians();

--- a/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleRadiansTest.java
+++ b/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleRadiansTest.java
@@ -69,6 +69,23 @@ public class PlaneAngleRadiansTest {
     }
 
     @Test
+    public void testNormalizeBetweenMinusPiAndPi_lowerBound() {
+        final double value = -Math.PI;
+        final double expected = -Math.PI;
+        final double actual = PlaneAngleRadians.normalizeBetweenMinusPiAndPi(value);
+        final double tol = Math.ulp(expected);
+        Assert.assertEquals(expected, actual, tol);
+    }
+    @Test
+    public void testNormalizeBetweenMinusPiAndPi_upperBound() {
+        final double value = +Math.PI;
+        final double expected = -Math.PI;
+        final double actual = PlaneAngleRadians.normalizeBetweenMinusPiAndPi(value);
+        final double tol = Math.ulp(expected);
+        Assert.assertEquals(expected, actual, tol);
+    }
+
+    @Test
     public void testNormalizeBetweenZeroAndTwoPi1() {
         final double value = 1.25 * TWO_PI;
         final double expected = 0.25 * TWO_PI;
@@ -96,6 +113,23 @@ public class PlaneAngleRadiansTest {
     public void testNormalizeBetweenZeroAndTwoPi4() {
         final double value = 9 * Math.PI / 4;
         final double expected = Math.PI / 4;
+        final double actual = PlaneAngleRadians.normalizeBetweenZeroAndTwoPi(value);
+        final double tol = Math.ulp(expected);
+        Assert.assertEquals(expected, actual, tol);
+    }
+
+    @Test
+    public void testNormalizeBetweenZeroAndTwoPi_lowerBound() {
+        final double value = 0.0;
+        final double expected = 0.0;
+        final double actual = PlaneAngleRadians.normalizeBetweenZeroAndTwoPi(value);
+        final double tol = Math.ulp(expected);
+        Assert.assertEquals(expected, actual, tol);
+    }
+    @Test
+    public void testNormalizeBetweenZeroAndTwoPi_upperBound() {
+        final double value = 2.0 * Math.PI;
+        final double expected = 0.0;
         final double actual = PlaneAngleRadians.normalizeBetweenZeroAndTwoPi(value);
         final double tol = Math.ulp(expected);
         Assert.assertEquals(expected, actual, tol);

--- a/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleTest.java
+++ b/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleTest.java
@@ -107,6 +107,25 @@ public class PlaneAngleTest {
     }
 
     @Test
+    public void testNormalizeUpperAndLowerBounds() {
+        // arrange
+        double eps = 1e-15;
+
+        // act/assert
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(-0.5).normalize(PlaneAngle.ZERO).toTurns(), eps);
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(0.5).normalize(PlaneAngle.ZERO).toTurns(), eps);
+
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(-1.5).normalize(PlaneAngle.ZERO).toTurns(), eps);
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(1.5).normalize(PlaneAngle.ZERO).toTurns(), eps);
+
+        Assert.assertEquals(0.0, PlaneAngle.ofTurns(0).normalize(PlaneAngle.PI).toTurns(), eps);
+        Assert.assertEquals(0.0, PlaneAngle.ofTurns(1).normalize(PlaneAngle.PI).toTurns(), eps);
+
+        Assert.assertEquals(0.0, PlaneAngle.ofTurns(-1).normalize(PlaneAngle.PI).toTurns(), eps);
+        Assert.assertEquals(0.0, PlaneAngle.ofTurns(2).normalize(PlaneAngle.PI).toTurns(), eps);
+    }
+
+    @Test
     public void testHashCode() {
         // Test assumes that the internal representation is in "turns".
         final double value = -123.456789;


### PR DESCRIPTION
The upper bound for the returned angle from the PlaneAngle.normalize() method is exclusive, although the documentation states that it is inclusive.