### PR TITLE
NUMBERS-94: PlaneAngle.normalize() fix for small numbers

### DIFF
--- a/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngle.java
+++ b/commons-numbers-angle/src/main/java/org/apache/commons/numbers/angle/PlaneAngle.java
@@ -94,7 +94,21 @@ public class PlaneAngle {
      * {@code center - 0.5 <= a - k < center + 0.5} (in turns).
      */
     public PlaneAngle normalize(PlaneAngle center) {
-        return new PlaneAngle(value - Math.floor(value + HALF_TURN - center.value));
+        final double lowerBound = center.value - HALF_TURN;
+        final double upperBound = center.value + HALF_TURN;
+
+        double normalized = value - Math.floor(value - lowerBound);
+
+        // If value is too small to be representable compared to the floor
+        // expression above (ie, if value + x = x), then we may end up with a number
+        // exactly equal to the upper bound here. In that case, subtract
+        // one from the normalized value so that we can fulfill the contract
+        // of only returning results strictly less than the upper bound.
+        if (normalized >= upperBound) {
+            normalized -= 1.0;
+        }
+
+        return new PlaneAngle(normalized);
     }
 
     /**

--- a/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleTest.java
+++ b/commons-numbers-angle/src/test/java/org/apache/commons/numbers/angle/PlaneAngleTest.java
@@ -126,6 +126,28 @@ public class PlaneAngleTest {
     }
 
     @Test
+    public void testNormalizeVeryCloseToBounds() {
+        // arrange
+        double eps = 1e-22;
+
+        double small = 1e-16;
+        double tiny = 1e-18; // 0.5 + tiny = 0.5 (the value is too small to add to 0.5)
+
+        // act/assert
+        Assert.assertEquals(1.0 - small, PlaneAngle.ofTurns(-small).normalize(PlaneAngle.PI).toTurns(), eps);
+        Assert.assertEquals(small, PlaneAngle.ofTurns(small).normalize(PlaneAngle.PI).toTurns(), eps);
+
+        Assert.assertEquals(0.5 - small, PlaneAngle.ofTurns(-0.5 - small).normalize(PlaneAngle.ZERO).toTurns(), eps);
+        Assert.assertEquals(-0.5 + small, PlaneAngle.ofTurns(0.5 + small).normalize(PlaneAngle.ZERO).toTurns(), eps);
+
+        Assert.assertEquals(0.0, PlaneAngle.ofTurns(-tiny).normalize(PlaneAngle.PI).toTurns(), eps);
+        Assert.assertEquals(tiny, PlaneAngle.ofTurns(tiny).normalize(PlaneAngle.PI).toTurns(), eps);
+
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(-0.5 - tiny).normalize(PlaneAngle.ZERO).toTurns(), eps);
+        Assert.assertEquals(-0.5, PlaneAngle.ofTurns(0.5 + tiny).normalize(PlaneAngle.ZERO).toTurns(), eps);
+    }
+
+    @Test
     public void testHashCode() {
         // Test assumes that the internal representation is in "turns".
         final double value = -123.456789;


### PR DESCRIPTION
Adding an extra check to the PlaneAngle.normalize() method to ensure that the return value is within the allowed range when given very small numbers.