### PR TITLE
Fix missing negation in Complex#sin()

### DIFF
--- a/commons-numbers-complex/src/main/java/org/apache/commons/numbers/complex/Complex.java
+++ b/commons-numbers-complex/src/main/java/org/apache/commons/numbers/complex/Complex.java
@@ -1084,7 +1084,7 @@ public final class Complex implements Serializable  {
      */
     public Complex sin() {
         return new Complex(Math.sin(real) * Math.cosh(imaginary),
-                           Math.cos(real) * Math.sinh(imaginary));
+                           -Math.cos(real) * Math.sinh(imaginary));
     }
 
     /**


### PR DESCRIPTION
The comment message of the method is actually correct, but the implementation lacks the negation.