### PR TITLE
NUMBERS-58: Fix MathJax for mvn javadoc plugin v3

### DIFF
--- a/commons-numbers-arrays/src/main/java/org/apache/commons/numbers/arrays/LinearCombination.java
+++ b/commons-numbers-arrays/src/main/java/org/apache/commons/numbers/arrays/LinearCombination.java
@@ -46,7 +46,7 @@ public class LinearCombination {
     /**
      * @param a Factors.
      * @param b Factors.
-     * @return \( \Sum_i a_i b_i \).
+     * @return \( \sum_i a_i b_i \).
      * @throws IllegalArgumentException if the sizes of the arrays are different.
      */
     public static double value(double[] a,

--- a/pom.xml
+++ b/pom.xml
@@ -262,16 +262,15 @@
       </plugin>
 
       <plugin>
-	<!-- NOTE: javadoc config must also be set under <reporting> -->
+      <!-- NOTE: javadoc config must also be set under <reporting> -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-        <!--  Enable MathJax -->
-                <additionalparam>${doclint.javadoc.qualifier} ${allowscript.javadoc.qualifier} -header '&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/${numbers.mathjax.version}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalparam>
+          <!--  Enable MathJax -->
+          <additionalOptions>${doclint.javadoc.qualifier} ${allowscript.javadoc.qualifier} -header '&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/${numbers.mathjax.version}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalOptions>
           <!-- <aggregate>true</aggregate> -->
         </configuration>
       </plugin>
-      
     </plugins>
 
     <pluginManagement>
@@ -389,8 +388,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-      	<!--  Enable MathJax -->
-		<additionalparam>${doclint.javadoc.qualifier} ${allowscript.javadoc.qualifier} -header '&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/${numbers.mathjax.version}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalparam>
+          <!--  Enable MathJax -->
+          <additionalOptions>${doclint.javadoc.qualifier} ${allowscript.javadoc.qualifier} -header '&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/${numbers.mathjax.version}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalOptions>
           <!-- <aggregate>true</aggregate> -->
         </configuration>
       </plugin>


### PR DESCRIPTION
This fixes MathJax support for maven javadoc plugin version 3.

I also fixed a latex formula that I found was broken when testing the output javadocs contained equations.
