### PR TITLE
Clarify Precision.equalsIncludingNan() methods

### DIFF
--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Precision.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Precision.java
@@ -175,7 +175,7 @@ public class Precision {
      * @return {@code true} if the values are equal or both are NaN.
      */
     public static boolean equalsIncludingNaN(float x, float y) {
-        return (x != x || y != y) ? !(x != x ^ y != y) : equals(x, y, 1);
+        return Float.isNaN(x) ? Float.isNaN(y) : equals(x, y, 1);
     }
 
     /**
@@ -268,7 +268,7 @@ public class Precision {
      * {@code maxUlps} floating point values between {@code x} and {@code y}.
      */
     public static boolean equalsIncludingNaN(float x, float y, int maxUlps) {
-        return (x != x || y != y) ? !(x != x ^ y != y) : equals(x, y, maxUlps);
+        return Float.isNaN(x) ? Float.isNaN(y) : equals(x, y, maxUlps);
     }
 
     /**
@@ -292,7 +292,7 @@ public class Precision {
      * @return {@code true} if the values are equal or both are NaN.
      */
     public static boolean equalsIncludingNaN(double x, double y) {
-        return (x != x || y != y) ? !(x != x ^ y != y) : equals(x, y, 1);
+        return Double.isNaN(x) ? Double.isNaN(y) : equals(x, y, 1);
     }
 
     /**
@@ -414,7 +414,7 @@ public class Precision {
      * {@code maxUlps} floating point values between {@code x} and {@code y}.
      */
     public static boolean equalsIncludingNaN(double x, double y, int maxUlps) {
-        return (x != x || y != y) ? !(x != x ^ y != y) : equals(x, y, maxUlps);
+        return Double.isNaN(x) ? Double.isNaN(y) : equals(x, y, maxUlps);
     }
 
     /**


### PR DESCRIPTION
Don't use `x != x` as a form of `Float.isNaN(x)`.