### PR TITLE
NUMBERS-113: Fix JUnit dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.0.0-M4</version>
+      <version>5.4.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.4.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-runner</artifactId>
-      <version>5.0.0-M4</version>
+      <version>1.4.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -206,18 +213,6 @@
           <!-- See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912333#63 -->
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.3.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.4.2</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
I'm not a JUnit expert, so I'm not sure if this is the optimal way to import both JUnit 5 and JUnit 4. But it does seem to solve the problems described in the JIRA ticket, so I'll just be bold and put this here.