### PR TITLE
NUMBERS-115: Remove obsolete JUnit 4 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,18 +113,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Remove the following dependencies:

org.junit.platform:junit-platform-runner
org.junit.vintage:junit-vintage-engine