### PR TITLE
[NUMBERS-133] Use iteration algorithm from bounded trial division in Primes.nextPrime(int)

### DIFF
--- a/commons-numbers-primes/src/main/java/org/apache/commons/numbers/primes/Primes.java
+++ b/commons-numbers-primes/src/main/java/org/apache/commons/numbers/primes/Primes.java
@@ -17,7 +17,10 @@
 package org.apache.commons.numbers.primes;
 
 import java.text.MessageFormat;
+
+import java.util.Arrays;
 import java.util.List;
+import java.util.PrimitiveIterator;
 
 
 /**
@@ -70,37 +73,21 @@ public class Primes {
     public static int nextPrime(int n) {
         if (n < 0) {
             throw new IllegalArgumentException(MessageFormat.format(NUMBER_TOO_SMALL, n, 0));
-        }
-        if (n == 2) {
-            return 2;
-        }
-        n |= 1; // make sure n is odd
-        if (n == 1) {
-            return 2;
-        }
-
-        if (isPrime(n)) {
-            return n;
-        }
-
-        // prepare entry in the +2, +4 loop:
-        // n should not be a multiple of 3
-        final int rem = n % 3;
-        if (0 == rem) { // if n % 3 == 0
-            n += 2; // n % 3 == 2
-        } else if (1 == rem) { // if n % 3 == 1
-            // if (isPrime(n)) return n;
-            n += 4; // n % 3 == 2
-        }
-        while (true) { // this loop skips all multiple of 3
-            if (isPrime(n)) {
-                return n;
+        } else if (n <= SmallPrimes.PRIMES_LAST) {
+            int index = Arrays.binarySearch(SmallPrimes.PRIMES, n);
+            if (index < 0) {
+                index = - (index + 1);
             }
-            n += 2; // n % 3 == 1
-            if (isPrime(n)) {
-                return n;
+            return SmallPrimes.PRIMES[index];
+        } else {
+            PrimitiveIterator.OfInt potentialPrimesIterator = SmallPrimes.potentialPrimes(n);
+            while (true) {
+                // Integer.MAX_VALUE is a prime number, so no risk of overflow
+                int candidate = potentialPrimesIterator.next();
+                if (isPrime(candidate)) {
+                    return candidate;
+                }
             }
-            n += 4; // n % 3 == 2
         }
     }
 

--- a/commons-numbers-primes/src/main/java/org/apache/commons/numbers/primes/SmallPrimes.java
+++ b/commons-numbers-primes/src/main/java/org/apache/commons/numbers/primes/SmallPrimes.java
@@ -175,43 +175,18 @@ class SmallPrimes {
     static int boundedTrialDivision(int n,
                                     int maxFactor,
                                     List<Integer> factors) {
-        int minFactor = PRIMES_LAST + 2;
-
-        /*
-        only trying integers of the form k*m + c, where k >= 0, m is the
-        product of some prime numbers which n is required not to contain
-        as prime factors, and c is an integer undivisible by all of those
-        prime numbers; in other words, skipping multiples of these primes
-         */
-        int m = PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getValue()[PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getValue().length - 1] + 1;
-        int km = m * (minFactor / m);
-        int currentEquivalenceClassIndex = Arrays.binarySearch(
-                PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getValue(),
-                minFactor % m);
-
-        /*
-        Since minFactor is the next smallest prime number after the
-        first 512 primes, it cannot be a multiple of one of them, therefore,
-        the index returned by the above binary search must be non-negative.
-         */
+        PrimitiveIterator.OfInt potentialPrimesIterator = potentialPrimes(PRIMES_LAST + 2);
 
         boolean done = false;
         while (!done) {
             // no check is done about n >= f
-            int f = km + PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getValue()[currentEquivalenceClassIndex];
+            int f = potentialPrimesIterator.next();
             if (f > maxFactor) {
                 done = true;
             } else if (0 == n % f) {
                 n /= f;
                 factors.add(f);
                 done = true;
-            } else {
-                if (currentEquivalenceClassIndex == PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getValue().length - 1) {
-                    km += m;
-                    currentEquivalenceClassIndex = 0;
-                } else {
-                    currentEquivalenceClassIndex++;
-                }
             }
         }
         if (n != 1) {

--- a/commons-numbers-primes/src/test/java/org/apache/commons/numbers/primes/SmallPrimesTest.java
+++ b/commons-numbers-primes/src/test/java/org/apache/commons/numbers/primes/SmallPrimesTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.PrimitiveIterator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -139,6 +140,48 @@ public class SmallPrimesTest {
             if (n %2 == 1) {
                 Assertions.assertFalse(SmallPrimes.millerRabinPrimeTest(n));
             }
+        }
+    }
+
+    @Test
+    public void testPotentialPrimes() {
+        testPotentialPrimes(-23456, 1500);
+        testPotentialPrimes(34567, 1500);
+        testPotentialPrimes(Integer.MAX_VALUE - 97, 1500);
+    }
+
+    private void testPotentialPrimes(int lowerBound, int maxIterations) {
+        PrimitiveIterator.OfInt potentialPrimesIterator = SmallPrimes.potentialPrimes(lowerBound);
+
+        int iterationCount = 0;
+        boolean overflow = false;
+        int previous = Math.max(0, lowerBound) - 1;
+        while (iterationCount != maxIterations && !overflow) {
+            Assertions.assertTrue(potentialPrimesIterator.hasNext());
+            int next = potentialPrimesIterator.nextInt();
+            if (next < 0) {
+                overflow = true;
+            }
+
+            for (int i = previous + 1;
+                 i >= 0 && i <= (overflow ? Integer.MAX_VALUE : next - 1);
+                 i++) {
+                boolean hasPrimeFactor = false;
+                for (Integer prime : SmallPrimes.PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getKey()) {
+                    if (i % prime == 0) {
+                        hasPrimeFactor = true;
+                        break;
+                    }
+                }
+                Assertions.assertTrue(hasPrimeFactor);
+            }
+            if (!overflow) {
+                for (Integer prime : SmallPrimes.PRIME_NUMBERS_AND_COPRIME_EQUIVALENCE_CLASSES.getKey()) {
+                    Assertions.assertNotEquals(0, next % prime);
+                }
+            }
+            previous = next;
+            iterationCount++;
         }
     }
 }


### PR DESCRIPTION
I'm not sure if "potentialPrimes" is a good name for the method that generates the iterator, because it doesn't reveal anything about the purpose of the argument (a lower bound). However, "potentialPrimesBeyond" or something similar would be wrong, because the argument itself is also included in the possible range of results. The most descriptive name would be "potentialPrimesGreaterThanOrEqualTo", but this is horribly verbose. "potentialPrimesNotSmallerThan" is only slightly less verbose, and it contains a negation, which is confusing. So I've left it at "potentialPrimes", but any better suggestions are welcome. At least it's a package-private method, so the method name could still be changed any time in the future.