### PR TITLE
[commons-numbers-core] use non-deprecated ref in docs

### DIFF
--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Precision.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Precision.java
@@ -435,7 +435,7 @@ public final class Precision {
 
     /**
      * Rounds the given value to the specified number of decimal places.
-     * The value is rounded using the {@link BigDecimal#ROUND_HALF_UP} method.
+     * The value is rounded using the {@link RoundingMode#HALF_UP} method.
      *
      * @param x Value to round.
      * @param scale Number of digits to the right of the decimal point.


### PR DESCRIPTION
The code was already changed but refer to the non-deprecated version in
documentaton as well.