### PR TITLE
NUMBERS-144: Fixing rat check failures from examples module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,10 @@
             <exclude>.ekstazi/**</exclude>
             <exclude>src/test/resources/data/**</exclude>
             <exclude>dist-archive/**</exclude>
+            <exclude>**/.classpath</exclude>
+            <exclude>**/.project</exclude>
+            <exclude>**/.settings/**</exclude>
+            <exclude>**/target/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Adding standard rat exclusions to prevent failures from files in the examples module.