### PR TITLE
NUMBERS-147: Fix Fraction conversion from double to support 2^31

### DIFF
--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -316,14 +316,21 @@ public final class BigFraction
      * @param epsilon Maximum error allowed. The resulting fraction is within
      * {@code epsilon} of {@code value}, in absolute terms.
      * @param maxIterations Maximum number of convergents.
-     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite.
+     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite;
+     * {@code epsilon} is not positive; or {@code maxIterations < 1}.
      * @throws ArithmeticException if the continued fraction failed to converge.
      * @return a new instance.
      */
     public static BigFraction from(final double value,
                                    final double epsilon,
                                    final int maxIterations) {
-        return from(value, epsilon, Integer.MIN_VALUE, maxIterations);
+        if (maxIterations < 1) {
+            throw new IllegalArgumentException("Max iterations must be strictly positiive: " + maxIterations);
+        }
+        if (epsilon >= 0) {
+            return from(value, epsilon, Integer.MIN_VALUE, maxIterations);
+        }
+        throw new IllegalArgumentException("Epsilon must be positiive: " + maxIterations);
     }
 
     /**

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -157,7 +157,7 @@ public final class BigFraction
         // check for (almost) integer arguments, which should not go to iterations.
         if (r0 - a0 <= epsilon) {
             // Restore the sign.
-            if (Math.signum(a0) != Math.signum(value)) {
+            if (value < 0) {
                 a0 = -a0;
             }
             return new BigFraction(BigInteger.valueOf(a0));

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -185,10 +185,11 @@ public final class BigFraction
             q2 = (a1 * q1) + q0;
             if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
                 Long.compareUnsigned(q2, OVERFLOW) > 0) {
-                // in maxDenominator mode, if the last fraction was very close to the actual value
-                // q2 may overflow in the next iteration; in this case return the last one if valid.
+                // In maxDenominator mode, fall-back to the previous valid fraction.
                 if (epsilon == 0 &&
                     q1 <= maxDen) {
+                    p2 = p1;
+                    q2 = q1;
                     break;
                 }
                 throw new FractionException(FractionException.ERROR_CONVERSION_OVERFLOW, value, p2, q2);

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -186,8 +186,7 @@ public final class BigFraction
             if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
                 Long.compareUnsigned(q2, OVERFLOW) > 0) {
                 // In maxDenominator mode, fall-back to the previous valid fraction.
-                if (epsilon == 0 &&
-                    q1 <= maxDen) {
+                if (epsilon == 0) {
                     p2 = p1;
                     q2 = q1;
                     break;
@@ -214,7 +213,7 @@ public final class BigFraction
             throw new FractionException(FractionException.ERROR_CONVERSION, value, maxIterations);
         }
 
-        // Use p2 / q2 or p1 / q1 if an overflow in maxDenominator mode
+        // Use p2 / q2 or p1 / q1 if q2 has grown too large in maxDenominator mode
         long num;
         long den;
         if (q2 <= maxDen) {

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -47,6 +47,9 @@ public final class BigFraction
     /** Serializable version identifier. */
     private static final long serialVersionUID = 20190701L;
 
+    /** The default iterations used for convergence. */
+    private static final int DEFAULT_MAX_ITERATIONS = 100;
+
     /** Message for non-finite input double argument to factory constructors. */
     private static final String NOT_FINITE = "Not finite: ";
 
@@ -349,7 +352,7 @@ public final class BigFraction
             // Re-use the zero denominator message
             throw new IllegalArgumentException(FractionException.ERROR_ZERO_DENOMINATOR);
         }
-        return from(value, 0, maxDenominator, 100);
+        return from(value, 0, maxDenominator, DEFAULT_MAX_ITERATIONS);
     }
 
     /**

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -325,6 +325,7 @@ public final class BigFraction
 
     /**
      * Create a fraction given the double value and maximum denominator.
+     *
      * <p>
      * References:
      * <ul>
@@ -332,14 +333,22 @@ public final class BigFraction
      * Continued Fraction</a> equations (11) and (22)-(26)</li>
      * </ul>
      *
+     * <p>Note: The magnitude of the {@code maxDenominator} is used allowing use of
+     * {@link Integer#MIN_VALUE} for a supported maximum denominator of 2<sup>31</sup>.
+     *
      * @param value Value to convert to a fraction.
      * @param maxDenominator Maximum allowed value for denominator.
-     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite.
+     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite
+     * or {@code maxDenominator} is zero.
      * @throws ArithmeticException if the continued fraction failed to converge.
      * @return a new instance.
      */
     public static BigFraction from(final double value,
                                    final int maxDenominator) {
+        if (maxDenominator == 0) {
+            // Re-use the zero denominator message
+            throw new IllegalArgumentException(FractionException.ERROR_ZERO_DENOMINATOR);
+        }
         return from(value, 0, maxDenominator, 100);
     }
 

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -183,12 +183,12 @@ public final class BigFraction
             final long a1 = (long) Math.floor(r1);
             p2 = (a1 * p1) + p0;
             q2 = (a1 * q1) + q0;
-            if (Math.abs(p2) > OVERFLOW ||
-                Math.abs(q2) > OVERFLOW) {
+            if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
+                Long.compareUnsigned(q2, OVERFLOW) > 0) {
                 // in maxDenominator mode, if the last fraction was very close to the actual value
                 // q2 may overflow in the next iteration; in this case return the last one if valid.
                 if (epsilon == 0 &&
-                    Math.abs(q1) <= maxDen) {
+                    q1 <= maxDen) {
                     break;
                 }
                 throw new FractionException(FractionException.ERROR_CONVERSION_OVERFLOW, value, p2, q2);

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -313,9 +313,13 @@ public final class Fraction
      * Continued Fraction</a> equations (11) and (22)-(26)</li>
      * </ul>
      *
+     * <p>Note: The magnitude of the {@code maxDenominator} is used allowing use of
+     * {@link Integer#MIN_VALUE} for a supported maximum denominator of 2<sup>31</sup>.
+     *
      * @param value Value to convert to a fraction.
      * @param maxDenominator Maximum allowed value for denominator.
-     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite.
+     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite
+     * or {@code maxDenominator} is zero.
      * @throws ArithmeticException if the continued fraction failed to converge.
      * @return a new instance.
      */
@@ -323,6 +327,10 @@ public final class Fraction
                                 final int maxDenominator) {
         if (value == 0) {
             return ZERO;
+        }
+        if (maxDenominator == 0) {
+            // Re-use the zero denominator message
+            throw new IllegalArgumentException(FractionException.ERROR_ZERO_DENOMINATOR);
         }
         return new Fraction(value, 0, maxDenominator, 100);
     }

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -207,12 +207,12 @@ public final class Fraction
             p2 = (a1 * p1) + p0;
             q2 = (a1 * q1) + q0;
 
-            if (Math.abs(p2) > OVERFLOW ||
-                Math.abs(q2) > OVERFLOW) {
+            if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
+                Long.compareUnsigned(q2, OVERFLOW) > 0) {
                 // in maxDenominator mode, if the last fraction was very close to the actual value
                 // q2 may overflow in the next iteration; in this case return the last one if valid.
                 if (epsilon == 0.0 &&
-                    Math.abs(q1) <= maxDen) {
+                    q1 <= maxDen) {
                     break;
                 }
                 throw new FractionException(FractionException.ERROR_CONVERSION_OVERFLOW, value, p2, q2);

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -209,10 +209,11 @@ public final class Fraction
 
             if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
                 Long.compareUnsigned(q2, OVERFLOW) > 0) {
-                // in maxDenominator mode, if the last fraction was very close to the actual value
-                // q2 may overflow in the next iteration; in this case return the last one if valid.
+                // In maxDenominator mode, fall-back to the previous valid fraction.
                 if (epsilon == 0.0 &&
                     q1 <= maxDen) {
+                    p2 = p1;
+                    q2 = q1;
                     break;
                 }
                 throw new FractionException(FractionException.ERROR_CONVERSION_OVERFLOW, value, p2, q2);

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -271,8 +271,7 @@ public final class Fraction
      *
      * @param value Value to convert to a fraction.
      * @throws IllegalArgumentException if the given {@code value} is NaN or infinite.
-     * @throws ArithmeticException if the continued fraction failed to
-     * converge.
+     * @throws ArithmeticException if the continued fraction failed to converge.
      * @return a new instance.
      */
     public static Fraction from(final double value) {
@@ -293,7 +292,8 @@ public final class Fraction
      * @param epsilon Maximum error allowed. The resulting fraction is within
      * {@code epsilon} of {@code value}, in absolute terms.
      * @param maxIterations Maximum number of convergents.
-     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite.
+     * @throws IllegalArgumentException if the given {@code value} is NaN or infinite;
+     * {@code epsilon} is not positive; or {@code maxIterations < 1}.
      * @throws ArithmeticException if the continued fraction failed to converge.
      * @return a new instance.
      */
@@ -303,7 +303,13 @@ public final class Fraction
         if (value == 0) {
             return ZERO;
         }
-        return new Fraction(value, epsilon, Integer.MIN_VALUE, maxIterations);
+        if (maxIterations < 1) {
+            throw new IllegalArgumentException("Max iterations must be strictly positiive: " + maxIterations);
+        }
+        if (epsilon >= 0) {
+            return new Fraction(value, epsilon, Integer.MIN_VALUE, maxIterations);
+        }
+        throw new IllegalArgumentException("Epsilon must be positiive: " + maxIterations);
     }
 
     /**

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -210,8 +210,7 @@ public final class Fraction
             if (Long.compareUnsigned(p2, OVERFLOW) > 0 ||
                 Long.compareUnsigned(q2, OVERFLOW) > 0) {
                 // In maxDenominator mode, fall-back to the previous valid fraction.
-                if (epsilon == 0.0 &&
-                    q1 <= maxDen) {
+                if (epsilon == 0.0) {
                     p2 = p1;
                     q2 = q1;
                     break;
@@ -238,7 +237,7 @@ public final class Fraction
             throw new FractionException(FractionException.ERROR_CONVERSION, value, maxIterations);
         }
 
-        // Use p2 / q2 or p1 / q1 if an overflow in maxDenominator mode
+        // Use p2 / q2 or p1 / q1 if q2 has grown too large in maxDenominator mode
         // Note: Conversion of long 2^31 to an integer will create a negative. This could
         // be either the numerator or denominator. This is handled by restoring the sign.
         int num;

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -47,6 +47,9 @@ public final class Fraction
     /** The default epsilon used for convergence. */
     private static final double DEFAULT_EPSILON = 1e-5;
 
+    /** The default iterations used for convergence. */
+    private static final int DEFAULT_MAX_ITERATIONS = 100;
+
     /** Message for non-finite input double argument to factory constructors. */
     private static final String NOT_FINITE = "Not finite: ";
 
@@ -273,7 +276,7 @@ public final class Fraction
      * @return a new instance.
      */
     public static Fraction from(final double value) {
-        return from(value, DEFAULT_EPSILON, 100);
+        return from(value, DEFAULT_EPSILON, DEFAULT_MAX_ITERATIONS);
     }
 
     /**
@@ -332,7 +335,7 @@ public final class Fraction
             // Re-use the zero denominator message
             throw new IllegalArgumentException(FractionException.ERROR_ZERO_DENOMINATOR);
         }
-        return new Fraction(value, 0, maxDenominator, 100);
+        return new Fraction(value, 0, maxDenominator, DEFAULT_MAX_ITERATIONS);
     }
 
     /**

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -146,19 +146,23 @@ public class BigFractionTest {
     }
 
     // MATH-181
+    // NUMBERS-147
     @Test
     public void testDoubleConstructorWithMaxDenominator() throws Exception {
-        assertFraction(2, 5, BigFraction.from(0.4,   9));
-        assertFraction(2, 5, BigFraction.from(0.4,  99));
-        assertFraction(2, 5, BigFraction.from(0.4, 999));
+        for (final CommonTestCases.DoubleToFractionTestCase testCase : CommonTestCases.doubleMaxDenomConstructorTestCases()) {
+            assertFraction(
+                    testCase.expectedNumerator,
+                    testCase.expectedDenominator,
+                    BigFraction.from(testCase.operand, testCase.maxDenominator)
+            );
+        }
 
-        assertFraction(3, 5,      BigFraction.from(0.6152,    9));
-        assertFraction(8, 13,     BigFraction.from(0.6152,   99));
-        assertFraction(510, 829,  BigFraction.from(0.6152,  999));
-        assertFraction(769, 1250, BigFraction.from(0.6152, 9999));
-
-        // MATH-996
-        assertFraction(1, 2, BigFraction.from(0.5000000001, 10));
+        // Cases with different exact results from BigFraction
+        final long pow31 = 1L << 31;
+        assertFraction(pow31, 1, BigFraction.from(Integer.MIN_VALUE * -1.0, 2));
+        assertFraction(pow31, 3, BigFraction.from(Integer.MIN_VALUE / -3.0, 10));
+        assertFraction(-1, pow31, BigFraction.from(1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertFraction(1, pow31, BigFraction.from(-1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
     }
 
     @Test
@@ -189,6 +193,20 @@ public class BigFractionTest {
         );
         Assertions.assertThrows(ArithmeticException.class,
             () -> BigFraction.from(-1e10, 1000)
+        );
+    }
+
+    @Test
+    public void testDoubleConstructorOverflow() {
+        assertDoubleConstructorOverflow(0.75000000001455192);
+        assertDoubleConstructorOverflow(1.0e10);
+        assertDoubleConstructorOverflow(-1.0e10);
+        assertDoubleConstructorOverflow(-43979.60679604749);
+    }
+
+    private void assertDoubleConstructorOverflow(final double a) {
+        Assertions.assertThrows(ArithmeticException.class,
+            () -> BigFraction.from(a, 1.0e-12, 1000)
         );
     }
 

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -168,7 +168,7 @@ public class BigFractionTest {
     }
 
     @Test
-    public void testDoubleConstructorThrowsWithNonFinite() {
+    public void testDoubleConstructorThrows() {
         final double eps = 1e-5;
         final int maxIterations = Integer.MAX_VALUE;
         final int maxDenominator = Integer.MAX_VALUE;
@@ -177,6 +177,11 @@ public class BigFractionTest {
             Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(value, eps, maxIterations));
             Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(value, maxDenominator));
         }
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(1.0, Double.NaN, maxIterations));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(1.0, -1.0, maxIterations));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(1.0, eps, 0));
+        // Test a zero epsilon is allowed
+        assertFraction(1, 1, BigFraction.from(1.0, 0, maxIterations));
     }
 
     @Test

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -163,6 +163,8 @@ public class BigFractionTest {
         assertFraction(pow31, 3, BigFraction.from(Integer.MIN_VALUE / -3.0, 10));
         assertFraction(-1, pow31, BigFraction.from(1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
         assertFraction(1, pow31, BigFraction.from(-1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BigFraction.from(1.0, 0));
     }
 
     @Test

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -157,7 +157,7 @@ public class BigFractionTest {
             );
         }
 
-        // Cases with different exact results from BigFraction
+        // Cases with different exact results from Fraction
         final long pow31 = 1L << 31;
         assertFraction(pow31, 1, BigFraction.from(Integer.MIN_VALUE * -1.0, 2));
         assertFraction(pow31, 3, BigFraction.from(Integer.MIN_VALUE / -3.0, 10));

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
@@ -238,6 +238,14 @@ final class CommonTestCases {
         testCases.add(new DoubleToFractionTestCase(0x1.0p-40, Integer.MAX_VALUE, 0, 1));
         testCases.add(new DoubleToFractionTestCase(-0x1.0p-40, Integer.MAX_VALUE, 0, 1));
 
+        // Overflow
+        testCases.add(new DoubleToFractionTestCase(Math.nextUp((double) Integer.MAX_VALUE), Integer.MIN_VALUE, Integer.MAX_VALUE, 1));
+        testCases.add(new DoubleToFractionTestCase(-Math.nextUp((double) Integer.MAX_VALUE), Integer.MIN_VALUE, -Integer.MAX_VALUE, 1));
+        testCases.add(new DoubleToFractionTestCase(Math.nextUp((double) Integer.MAX_VALUE) / (1 << 15), Integer.MIN_VALUE, Integer.MAX_VALUE, 1 << 15));
+        testCases.add(new DoubleToFractionTestCase(-Math.nextUp((double) Integer.MAX_VALUE) / (1 << 15), Integer.MIN_VALUE, -Integer.MAX_VALUE, 1 << 15));
+        testCases.add(new DoubleToFractionTestCase(Math.nextUp(1.0), Integer.MIN_VALUE, 1, 1));
+        testCases.add(new DoubleToFractionTestCase(-Math.nextUp(1.0), Integer.MIN_VALUE, -1, 1));
+
         // MATH-996
         testCases.add(new DoubleToFractionTestCase(0.5000000001, 10, 1, 2));
         testCases.add(new DoubleToFractionTestCase(-0.5000000001, 10, -1, 2));

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
@@ -583,7 +583,7 @@ final class CommonTestCases {
      * allowed, and the expected numerator and denominator of the resulting
      * fraction are in the {@code int} range.
      *
-     * <p>The maximum denominator in the test case will zero and should be ignored.
+     * <p>The maximum denominator in the test cases will be zero and should be ignored.
      *
      * @return a list of test cases as described above
      */

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/CommonTestCases.java
@@ -38,6 +38,11 @@ final class CommonTestCases {
     private static final List<DoubleToFractionTestCase> doubleConstructorTestCasesList;
 
     /**
+     * See {@link #doubleMaxDenomConstructorTestCases()}
+     */
+    private static final List<DoubleToFractionTestCase> doubleMaxDenomConstructorTestCasesList;
+
+    /**
      * See {@link #absTestCases()}
      */
     private static final List<UnaryOperatorTestCase> absTestCasesList;
@@ -100,6 +105,7 @@ final class CommonTestCases {
     static {
         numDenConstructorTestCasesList = collectNumDenConstructorTestCases();
         doubleConstructorTestCasesList = collectDoubleConstructorTestCases();
+        doubleMaxDenomConstructorTestCasesList = collectDoubleMaxDenomConstructorTestCases();
         absTestCasesList = collectAbsTestCases();
         reciprocalTestCasesList = collectReciprocalTestCases();
         negateTestCasesList = collectNegateTestCases();
@@ -201,6 +207,55 @@ final class CommonTestCases {
         testCases.add(new DoubleToFractionTestCase(15.0, 15, 1));
         testCases.add(new DoubleToFractionTestCase(0.0, 0, 1));
         testCases.add(new DoubleToFractionTestCase(-0.0, 0, 1));
+
+        return testCases;
+    }
+
+    /**
+     * Defines test cases as described in
+     * {@link #doubleMaxDenomConstructorTestCases()} and collects them into a {@code List}.
+     * @return a list of test cases as described above
+     */
+    private static List<DoubleToFractionTestCase> collectDoubleMaxDenomConstructorTestCases() {
+        final List<DoubleToFractionTestCase> testCases = new ArrayList<>();
+        testCases.add(new DoubleToFractionTestCase(0.4,   9, 2, 5));
+        testCases.add(new DoubleToFractionTestCase(0.4,  99, 2, 5));
+        testCases.add(new DoubleToFractionTestCase(0.4, 999, 2, 5));
+        testCases.add(new DoubleToFractionTestCase(-0.4,   9, -2, 5));
+        testCases.add(new DoubleToFractionTestCase(-0.4,  99, -2, 5));
+        testCases.add(new DoubleToFractionTestCase(-0.4, 999, -2, 5));
+
+        testCases.add(new DoubleToFractionTestCase(0.6152,    9, 3, 5));
+        testCases.add(new DoubleToFractionTestCase(0.6152,   99, 8, 13));
+        testCases.add(new DoubleToFractionTestCase(0.6152,  999, 510, 829));
+        testCases.add(new DoubleToFractionTestCase(0.6152, 9999, 769, 1250));
+        testCases.add(new DoubleToFractionTestCase(-0.6152,    9, -3, 5));
+        testCases.add(new DoubleToFractionTestCase(-0.6152,   99, -8, 13));
+        testCases.add(new DoubleToFractionTestCase(-0.6152,  999, -510, 829));
+        testCases.add(new DoubleToFractionTestCase(-0.6152, 9999, -769, 1250));
+
+        // Underflow
+        testCases.add(new DoubleToFractionTestCase(0x1.0p-40, Integer.MAX_VALUE, 0, 1));
+        testCases.add(new DoubleToFractionTestCase(-0x1.0p-40, Integer.MAX_VALUE, 0, 1));
+
+        // MATH-996
+        testCases.add(new DoubleToFractionTestCase(0.5000000001, 10, 1, 2));
+        testCases.add(new DoubleToFractionTestCase(-0.5000000001, 10, -1, 2));
+
+        // NUMBERS-147
+        testCases.add(new DoubleToFractionTestCase(Integer.MAX_VALUE * 1.0, 2, Integer.MAX_VALUE, 1));
+        testCases.add(new DoubleToFractionTestCase(Integer.MAX_VALUE * -1.0, 2, -Integer.MAX_VALUE, 1));
+        testCases.add(new DoubleToFractionTestCase(1.0 / Integer.MAX_VALUE, Integer.MAX_VALUE, 1, Integer.MAX_VALUE));
+        testCases.add(new DoubleToFractionTestCase(-1.0 / Integer.MAX_VALUE, Integer.MAX_VALUE, -1, Integer.MAX_VALUE));
+        testCases.add(new DoubleToFractionTestCase(Integer.MIN_VALUE * 1.0, 2, Integer.MIN_VALUE, 1));
+
+        // Using 2^31:
+        // Representations in Fraction and BigFraction are different since BigFraction
+        // can use +2^31 but Fraction is limited to -2^31
+        // .from(Integer.MIN_VALUE * -1.0, 2)
+        // .from(Integer.MIN_VALUE / -3.0, Integer.MIN_VALUE)
+        // .from(1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE)
+        // .from(-1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE)
 
         return testCases;
     }
@@ -528,10 +583,24 @@ final class CommonTestCases {
      * allowed, and the expected numerator and denominator of the resulting
      * fraction are in the {@code int} range.
      *
+     * <p>The maximum denominator in the test case will zero and should be ignored.
+     *
      * @return a list of test cases as described above
      */
     static List<DoubleToFractionTestCase> doubleConstructorTestCases() {
         return Collections.unmodifiableList(doubleConstructorTestCasesList);
+    }
+
+    /**
+     * Provides a list of test cases where a {@code double} value should be
+     * converted to a fraction with a specified maximum denominator, and the
+     * expected numerator and denominator of the resulting fraction are in the
+     * {@code int} range.
+     *
+     * @return a list of test cases as described above
+     */
+    static List<DoubleToFractionTestCase> doubleMaxDenomConstructorTestCases() {
+        return Collections.unmodifiableList(doubleMaxDenomConstructorTestCasesList);
     }
 
     /**
@@ -791,19 +860,32 @@ final class CommonTestCases {
      * should be performed on a {@code double} value and the numerator and
      * denominator of the expected result
      * are in the {@code int} range.
+     *
+     * <p>Optionally captures a maximum denominator. This will be zero if
+     * not required in the test case.
      */
     static class DoubleToFractionTestCase {
         final double operand;
+        final int maxDenominator;
         final int expectedNumerator;
         final int expectedDenominator;
 
         DoubleToFractionTestCase(
                 double operand,
+                int maxDenominator,
                 int expectedNumerator,
                 int expectedDenominator) {
             this.operand = operand;
+            this.maxDenominator = maxDenominator;
             this.expectedNumerator = expectedNumerator;
             this.expectedDenominator = expectedDenominator;
+        }
+
+        DoubleToFractionTestCase(
+                double operand,
+                int expectedNumerator,
+                int expectedDenominator) {
+            this(operand, 0, expectedNumerator, expectedDenominator);
         }
     }
 }

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -99,19 +99,22 @@ public class FractionTest {
     }
 
     // MATH-181
+    // NUMBERS-147
     @Test
     public void testDoubleConstructorWithMaxDenominator() throws Exception  {
-        assertFraction(2, 5, Fraction.from(0.4,   9));
-        assertFraction(2, 5, Fraction.from(0.4,  99));
-        assertFraction(2, 5, Fraction.from(0.4, 999));
+        for (final CommonTestCases.DoubleToFractionTestCase testCase : CommonTestCases.doubleMaxDenomConstructorTestCases()) {
+            assertFraction(
+                    testCase.expectedNumerator,
+                    testCase.expectedDenominator,
+                    Fraction.from(testCase.operand, testCase.maxDenominator)
+            );
+        }
 
-        assertFraction(3, 5,      Fraction.from(0.6152,    9));
-        assertFraction(8, 13,     Fraction.from(0.6152,   99));
-        assertFraction(510, 829,  Fraction.from(0.6152,  999));
-        assertFraction(769, 1250, Fraction.from(0.6152, 9999));
-
-        // MATH-996
-        assertFraction(1, 2, Fraction.from(0.5000000001, 10));
+        // Cases with different exact results from BigFraction
+        assertFraction(Integer.MIN_VALUE, -1, Fraction.from(Integer.MIN_VALUE * -1.0, 2));
+        assertFraction(Integer.MIN_VALUE, -3, Fraction.from(Integer.MIN_VALUE / -3.0, 10));
+        assertFraction(1, Integer.MIN_VALUE, Fraction.from(1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertFraction(-1, Integer.MIN_VALUE, Fraction.from(-1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
     }
 
     @Test
@@ -131,6 +134,17 @@ public class FractionTest {
         // the golden ratio is notoriously a difficult number for continuous fraction
         Assertions.assertThrows(ArithmeticException.class,
             () -> Fraction.from((1 + Math.sqrt(5)) / 2, 1.0e-12, 25)
+        );
+    }
+
+    // MATH-1029
+    @Test
+    public void testDoubleConstructorWithMaxDenominatorOverFlow() {
+        Assertions.assertThrows(ArithmeticException.class,
+            () -> Fraction.from(1e10, 1000)
+        );
+        Assertions.assertThrows(ArithmeticException.class,
+            () -> Fraction.from(-1e10, 1000)
         );
     }
 

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -120,7 +120,7 @@ public class FractionTest {
     }
 
     @Test
-    public void testDoubleConstructorThrowsWithNonFinite() {
+    public void testDoubleConstructorThrows() {
         final double eps = 1e-5;
         final int maxIterations = Integer.MAX_VALUE;
         final int maxDenominator = Integer.MAX_VALUE;
@@ -129,6 +129,11 @@ public class FractionTest {
             Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(value, eps, maxIterations));
             Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(value, maxDenominator));
         }
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(1.0, Double.NaN, maxIterations));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(1.0, -1.0, maxIterations));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(1.0, eps, 0));
+        // Test a zero epsilon is allowed
+        assertFraction(1, 1, Fraction.from(1.0, 0, maxIterations));
     }
 
     @Test

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -115,6 +115,8 @@ public class FractionTest {
         assertFraction(Integer.MIN_VALUE, -3, Fraction.from(Integer.MIN_VALUE / -3.0, 10));
         assertFraction(1, Integer.MIN_VALUE, Fraction.from(1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
         assertFraction(-1, Integer.MIN_VALUE, Fraction.from(-1.0 / Integer.MIN_VALUE, Integer.MIN_VALUE));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Fraction.from(1.0, 0));
     }
 
     @Test


### PR DESCRIPTION
The value 2^31 can be in the numerator or denominator. Previously the
conversion from double supported up to Integer.MAX_VALUE which is
2^31-1.

Adds common test cases for conversion from double with a max
denominator.

Changed the conversion from a double to use the absolute value and
restore the sign at the end. The conversion is thus identical for
positive or negative values.

A maximum denominator of zero is not allowed and results in an IllegalArgumentException.
