### PR TITLE
Updated the checkstyle supressions file

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -48,8 +48,8 @@
   <suppress checks="IllegalCatch" files=".*[/\\]test[/\\].*" />
   <suppress checks="MethodName" files=".*[/\\]test[/\\].*" />
   <suppress checks="ConstantName" files=".*[/\\]test[/\\].*" />
-  <suppress checks="MethodLength" files=".*/LinearCombination.*Test.java" />
+  <suppress checks="MethodLength" files=".*[/\\]LinearCombination.*Test.java" />
   <suppress checks="FileLengthCheck" files=".*[/\\]gamma[/\\]BoostGammaTest.java" />
-  <suppress checks="MethodLength" files=".*/BoostBetaTest.java" />
+  <suppress checks="MethodLength" files=".*[/\\]BoostBetaTest.java" />
   <suppress checks="UnnecessaryParentheses" files=".*[/\\]gamma[/\\]BoostGammaTest.java" />
 </suppressions>


### PR DESCRIPTION
Added missing regexes for paths to support both Windows and *nix.

On Windows, the path separator is `\` not `/`.
As a result, the build fails due to Checkstyle violations.