### PR TITLE
NUMBERS-205: Introduces isZero() to Addition and isOne() to Multiplication

### DIFF
--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
@@ -44,4 +44,12 @@ public interface Addition<T> {
      * @return {@code -this}.
      */
     T negate();
+
+    /**
+     * Is this the zero element? Implementations may want to employ more efficient
+     * means than calling equals on the zero element.
+     *
+     * @return {@code true} if {@code this} equals the result of {@link #zero}.
+     */
+    boolean isZero();
 }

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
@@ -51,5 +51,7 @@ public interface Addition<T> {
      *
      * @return {@code true} if {@code this} equals the result of {@link #zero}.
      */
-    boolean isZero();
+    default boolean isZero() {
+        return this.equals(zero());
+    }
 }

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Addition.java
@@ -46,10 +46,13 @@ public interface Addition<T> {
     T negate();
 
     /**
-     * Is this the zero element? Implementations may want to employ more efficient
-     * means than calling equals on the zero element.
+     * Is this a neutral element of addition, i.e. {@code this.add(a)} typically returns {@code a}
+     * or an element representing the same value as {@code a}? Implementations may want to
+     * employ more efficient means than calling {@code equals()} on the zero element. This may even
+     * be required if an implementation has more than one binary representation of zero and its
+     * {@code equals()} method does make a difference between them.
      *
-     * @return {@code true} if {@code this} equals the result of {@link #zero}.
+     * @return {@code true} if {@code this} is a neutral element of addition.
      */
     default boolean isZero() {
         return this.equals(zero());

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
@@ -1924,6 +1924,18 @@ public final class DD
         return computePow(x, xx, n);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean isZero() {
+        return equals(0.0, x) && equals(0.0, xx);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return equals(1.0, x) && equals(0.0, xx);
+    }
+
     /**
      * Compute the number {@code x} (non-zero finite) raised to the power {@code n}.
      *

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
@@ -1924,20 +1924,6 @@ public final class DD
         return computePow(x, xx, n);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isZero() {
-        // we have guaranteed |x| > |xx|
-        // and Java provides 0.0 == -0.0
-        return x == 0.0;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isOne() {
-        return x == 1.0 && xx == 0.0;
-    }
-
     /**
      * Compute the number {@code x} (non-zero finite) raised to the power {@code n}.
      *
@@ -2311,6 +2297,13 @@ public final class DD
         return ZERO;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean isZero() {
+        // we keep |x| > |xx| and Java provides 0.0 == -0.0
+        return x == 0.0;
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -2321,6 +2314,12 @@ public final class DD
     @Override
     public DD one() {
         return ONE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return x == 1.0 && xx == 0.0;
     }
 
     /**

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/DD.java
@@ -1927,13 +1927,15 @@ public final class DD
     /** {@inheritDoc} */
     @Override
     public boolean isZero() {
-        return equals(0.0, x) && equals(0.0, xx);
+        // we have guaranteed |x| > |xx|
+        // and Java provides 0.0 == -0.0
+        return x == 0.0;
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean isOne() {
-        return equals(1.0, x) && equals(0.0, xx);
+        return x == 1.0 && xx == 0.0;
     }
 
     /**

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
@@ -51,5 +51,7 @@ public interface Multiplication<T> {
      *
      * @return {@code true} if {@code this} equals the result of {@link #one}.
      */
-    boolean isOne();
+    default boolean isOne() {
+        return this.equals(one());
+    };
 }

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
@@ -44,4 +44,12 @@ public interface Multiplication<T> {
      * @return <code>this<sup>-1</sup></code>.
      */
     T reciprocal();
+
+    /**
+     * Is this the neutral element of multiplication? Implementations may want to
+     * employ more efficient means than calling equals on the one element.
+     *
+     * @return {@code true} if {@code this} equals the result of {@link #one}.
+     */
+    boolean isOne();
 }

--- a/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
+++ b/commons-numbers-core/src/main/java/org/apache/commons/numbers/core/Multiplication.java
@@ -46,10 +46,13 @@ public interface Multiplication<T> {
     T reciprocal();
 
     /**
-     * Is this the neutral element of multiplication? Implementations may want to
-     * employ more efficient means than calling equals on the one element.
+     * Is this a neutral element of multiplication, i.e. {@code this.multiply(a)} typically
+     * returns {@code a} or an element representing the same value as {@code a}? Implementations may
+     * want to employ more efficient means than calling {@code equals()} on the one element. This
+     * may even be required if an implementation has more than one binary representation of one and
+     * its {@code equals()} method does make a difference between them.
      *
-     * @return {@code true} if {@code this} equals the result of {@link #one}.
+     * @return {@code true} if {@code this} a neutral element of multiplication
      */
     default boolean isOne() {
         return this.equals(one());

--- a/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/AdditionTest.java
+++ b/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/AdditionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.numbers.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for default methods of {@link Addition}.
+ */
+class AdditionTest {
+    private static class AdditionTester implements Addition<AdditionTester> {
+        private final int value;
+
+        AdditionTester(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public AdditionTester add(AdditionTester a) {
+            throw new UnsupportedOperationException("not needed for testing");
+        }
+
+        @Override
+        public AdditionTester zero() {
+            return new AdditionTester(0);
+        }
+
+        @Override
+        public AdditionTester negate() {
+            throw new UnsupportedOperationException("not needed for testing");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            AdditionTester that = (AdditionTester) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return value;
+        }
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(new AdditionTester(0).isZero());
+        Assertions.assertFalse(new AdditionTester(1).isZero());
+    }
+}

--- a/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
+++ b/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
@@ -78,6 +78,22 @@ class DDTest {
         Assertions.assertSame(DD.ZERO, DD.of(1.23).zero());
     }
 
+    @Test
+    void testIsOne() {
+        Assertions.assertTrue(DD.ONE.isOne());
+        Assertions.assertTrue(DD.of(0.5, 0).add(DD.of(0.5, 0)).isOne());
+        DD wide = DD.ofSum(1e300, 1e-300);
+        Assertions.assertTrue(wide.divide(wide).isOne());
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(DD.ZERO.isZero());
+        Assertions.assertTrue(DD.of(0.5, 0).subtract(DD.of(0.5, 0)).isZero());
+        DD wide = DD.ofSum(1e300, 1e-300);
+        Assertions.assertTrue(wide.multiply(DD.of(0.0)).isZero());
+    }
+
     @ParameterizedTest
     @ValueSource(doubles = {0, 1, Math.PI, Double.MIN_VALUE, Double.MAX_VALUE, Double.POSITIVE_INFINITY, Double.NaN})
     void testOfDouble(double x) {

--- a/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
+++ b/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
@@ -82,11 +82,13 @@ class DDTest {
     void testIsOne() {
         Assertions.assertTrue(DD.ONE.isOne());
         Assertions.assertTrue(DD.of(0.5, 0).add(DD.of(0.5, 0)).isOne());
-        DD wide = DD.ofSum(1e300, 1e-300);
-        Assertions.assertTrue(wide.divide(wide).isOne());
+        DD value = DD.ofSum(1e300, 1e-300);
+        Assertions.assertTrue(value.divide(value).isOne());
 
         Assertions.assertFalse(DD.ZERO.isOne());
         Assertions.assertFalse(DD.of(0.5).isOne());
+        Assertions.assertFalse(DD.of(0.5, 1e-20).isOne());
+        Assertions.assertFalse(DD.ofSum(1.0, 1e-20).isOne());
     }
 
     @Test
@@ -94,12 +96,11 @@ class DDTest {
         Assertions.assertTrue(DD.ZERO.isZero());
         Assertions.assertTrue(DD.of(-0.0).isZero());
         Assertions.assertTrue(DD.of(0.5, 0).subtract(DD.of(0.5, 0)).isZero());
-        DD wide = DD.ofSum(1e300, 1e-300);
-        Assertions.assertTrue(wide.multiply(DD.of(0.0)).isZero());
+        DD value = DD.ofSum(1e300, 1e-300);
+        Assertions.assertTrue(value.multiply(DD.of(0.0)).isZero());
 
         Assertions.assertFalse(DD.ONE.isZero());
         Assertions.assertFalse(DD.of(3.1415926).isZero());
-
     }
 
     @ParameterizedTest

--- a/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
+++ b/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/DDTest.java
@@ -84,14 +84,22 @@ class DDTest {
         Assertions.assertTrue(DD.of(0.5, 0).add(DD.of(0.5, 0)).isOne());
         DD wide = DD.ofSum(1e300, 1e-300);
         Assertions.assertTrue(wide.divide(wide).isOne());
+
+        Assertions.assertFalse(DD.ZERO.isOne());
+        Assertions.assertFalse(DD.of(0.5).isOne());
     }
 
     @Test
     void testIsZero() {
         Assertions.assertTrue(DD.ZERO.isZero());
+        Assertions.assertTrue(DD.of(-0.0).isZero());
         Assertions.assertTrue(DD.of(0.5, 0).subtract(DD.of(0.5, 0)).isZero());
         DD wide = DD.ofSum(1e300, 1e-300);
         Assertions.assertTrue(wide.multiply(DD.of(0.0)).isZero());
+
+        Assertions.assertFalse(DD.ONE.isZero());
+        Assertions.assertFalse(DD.of(3.1415926).isZero());
+
     }
 
     @ParameterizedTest

--- a/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/MultiplicationTest.java
+++ b/commons-numbers-core/src/test/java/org/apache/commons/numbers/core/MultiplicationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.numbers.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for default methods of {@link Multiplication}.
+ */
+class MultiplicationTest {
+    private static class MultiplicationTester implements Multiplication<MultiplicationTester> {
+        private final int value;
+
+        MultiplicationTester(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public MultiplicationTester multiply(MultiplicationTester a) {
+            throw new UnsupportedOperationException("not needed for testing");
+        }
+
+        @Override
+        public MultiplicationTester one() {
+            return new MultiplicationTester(1);
+        }
+
+        @Override
+        public MultiplicationTester reciprocal() {
+            throw new UnsupportedOperationException("not needed for testing");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MultiplicationTester that = (MultiplicationTester) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return value;
+        }
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(new MultiplicationTester(1).isOne());
+        Assertions.assertFalse(new MultiplicationTester(0).isOne());
+    }
+}

--- a/commons-numbers-field/src/main/java/org/apache/commons/numbers/field/FP64.java
+++ b/commons-numbers-field/src/main/java/org/apache/commons/numbers/field/FP64.java
@@ -105,6 +105,18 @@ public final class FP64 extends Number
 
     /** {@inheritDoc} */
     @Override
+    public boolean isZero() {
+        return value == 0.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return value == 1.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public boolean equals(Object other) {
         if (other instanceof FP64) {
             final FP64 o = (FP64) other;

--- a/commons-numbers-field/src/main/java/org/apache/commons/numbers/field/FP64.java
+++ b/commons-numbers-field/src/main/java/org/apache/commons/numbers/field/FP64.java
@@ -105,18 +105,6 @@ public final class FP64 extends Number
 
     /** {@inheritDoc} */
     @Override
-    public boolean isZero() {
-        return value == 0.0;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isOne() {
-        return value == 1.0;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public boolean equals(Object other) {
         if (other instanceof FP64) {
             final FP64 o = (FP64) other;
@@ -179,7 +167,19 @@ public final class FP64 extends Number
 
     /** {@inheritDoc} */
     @Override
+    public boolean isZero() {
+        return value == 0.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public FP64 one() {
         return ONE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return value == 1.0;
     }
 }

--- a/commons-numbers-field/src/test/java/org/apache/commons/numbers/field/FP64Test.java
+++ b/commons-numbers-field/src/test/java/org/apache/commons/numbers/field/FP64Test.java
@@ -102,6 +102,28 @@ class FP64Test {
     }
 
     @Test
+    void testIsOne() {
+        Assertions.assertTrue(FP64.of(1.0).isOne());
+        Assertions.assertTrue(FP64.of(0.5).add(FP64.of(0.5)).isOne());
+        FP64 wide = FP64.of(1e300);
+        Assertions.assertTrue(wide.divide(wide).isOne());
+        // avoid weirdness
+        Assertions.assertFalse(FP64.of(3).isOne());
+        Assertions.assertFalse(FP64.of(0.0).isOne());
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(FP64.of(0.0).isZero());
+        Assertions.assertTrue(FP64.of(0.5).subtract(FP64.of(0.5)).isZero());
+        FP64 wide = FP64.of(1e300);
+        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+        // avoid weirdness
+        Assertions.assertFalse(FP64.of(3).isZero());
+        Assertions.assertFalse(FP64.of(1.0).isZero());
+    }
+
+    @Test
     void testSubtract() {
         final double a = 123.4;
         final double b = 5678.9;

--- a/commons-numbers-field/src/test/java/org/apache/commons/numbers/field/FP64Test.java
+++ b/commons-numbers-field/src/test/java/org/apache/commons/numbers/field/FP64Test.java
@@ -105,8 +105,8 @@ class FP64Test {
     void testIsOne() {
         Assertions.assertTrue(FP64.of(1.0).isOne());
         Assertions.assertTrue(FP64.of(0.5).add(FP64.of(0.5)).isOne());
-        FP64 wide = FP64.of(1e300);
-        Assertions.assertTrue(wide.divide(wide).isOne());
+        FP64 value = FP64.of(1e300);
+        Assertions.assertTrue(value.divide(value).isOne());
         // avoid weirdness
         Assertions.assertFalse(FP64.of(3).isOne());
         Assertions.assertFalse(FP64.of(0.0).isOne());
@@ -116,8 +116,8 @@ class FP64Test {
     void testIsZero() {
         Assertions.assertTrue(FP64.of(0.0).isZero());
         Assertions.assertTrue(FP64.of(0.5).subtract(FP64.of(0.5)).isZero());
-        FP64 wide = FP64.of(1e300);
-        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+        FP64 value = FP64.of(1e300);
+        Assertions.assertTrue(value.multiply(value.zero()).isZero());
         // avoid weirdness
         Assertions.assertFalse(FP64.of(3).isZero());
         Assertions.assertFalse(FP64.of(1.0).isZero());

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -503,9 +503,21 @@ public final class BigFraction
         return ZERO;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean isZero() {
+        return numerator.signum() == 0;
+    }
+
     @Override
     public BigFraction one() {
         return ONE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return numerator.equals(denominator);
     }
 
     /**
@@ -996,21 +1008,6 @@ public final class BigFraction
         // exponents (long, BigInteger) are currently not supported.
         return new BigFraction(denominator.pow(-exponent),
                                numerator.pow(-exponent));
-    }
-
-    /**
-     * Returns true if this fraction is zero.
-     *
-     * @return true if zero
-     */
-    @Override
-    public boolean isZero() {
-        return numerator.signum() == 0;
-    }
-
-    @Override
-    public boolean isOne() {
-        return numerator.equals(denominator);
     }
 
     /**

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/BigFraction.java
@@ -999,6 +999,21 @@ public final class BigFraction
     }
 
     /**
+     * Returns true if this fraction is zero.
+     *
+     * @return true if zero
+     */
+    @Override
+    public boolean isZero() {
+        return numerator.signum() == 0;
+    }
+
+    @Override
+    public boolean isOne() {
+        return numerator.equals(denominator);
+    }
+
+    /**
      * Returns the {@code String} representing this fraction.
      * Uses:
      * <ul>
@@ -1279,14 +1294,5 @@ public final class BigFraction
         }
 
         return result;
-    }
-
-    /**
-     * Returns true if this fraction is zero.
-     *
-     * @return true if zero
-     */
-    private boolean isZero() {
-        return numerator.signum() == 0;
     }
 }

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -423,9 +423,21 @@ public final class Fraction
         return ZERO;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean isZero() {
+        return numerator == 0;
+    }
+
     @Override
     public Fraction one() {
         return ONE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return numerator == denominator;
     }
 
     /**
@@ -801,18 +813,6 @@ public final class Fraction
         }
         return new Fraction(ArithmeticUtils.pow(denominator, -exponent),
                             ArithmeticUtils.pow(numerator, -exponent));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isZero() {
-        return numerator == 0;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isOne() {
-        return numerator == denominator;
     }
 
     /**

--- a/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
+++ b/commons-numbers-fraction/src/main/java/org/apache/commons/numbers/fraction/Fraction.java
@@ -803,6 +803,18 @@ public final class Fraction
                             ArithmeticUtils.pow(numerator, -exponent));
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean isZero() {
+        return numerator == 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isOne() {
+        return numerator == denominator;
+    }
+
     /**
      * Returns the {@code String} representing this fraction.
      * Uses:
@@ -897,14 +909,5 @@ public final class Fraction
         final int numS = Integer.signum(numerator);
         final int denS = Integer.signum(denominator);
         return (31 * (31 + numerator * numS) + denominator * denS) * numS * denS;
-    }
-
-    /**
-     * Returns true if this fraction is zero.
-     *
-     * @return true if zero
-     */
-    private boolean isZero() {
-        return numerator == 0;
     }
 }

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -241,8 +241,8 @@ class BigFractionTest {
     void testIsZero() {
         Assertions.assertTrue(BigFraction.of(0, 4712).isZero());
         Assertions.assertTrue(BigFraction.of(3).subtract(BigFraction.of(3)).isZero());
-        BigFraction wide = BigFraction.of(11, 1111111111);
-        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+        BigFraction value = BigFraction.of(11, 1111111111);
+        Assertions.assertTrue(value.multiply(value.zero()).isZero());
     }
 
     @Test

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/BigFractionTest.java
@@ -230,6 +230,22 @@ class BigFractionTest {
     }
 
     @Test
+    void testIsOne() {
+        Assertions.assertTrue(BigFraction.of(1).isOne());
+        Assertions.assertTrue(BigFraction.of(1, 2).multiply(BigFraction.of(2)).isOne());
+        BigFraction value = BigFraction.of(17, 33);
+        Assertions.assertTrue(value.multiply(value.reciprocal()).isOne());
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(BigFraction.of(0, 4712).isZero());
+        Assertions.assertTrue(BigFraction.of(3).subtract(BigFraction.of(3)).isZero());
+        BigFraction wide = BigFraction.of(11, 1111111111);
+        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+    }
+
+    @Test
     void testCompareTo() {
         final BigFraction a = BigFraction.of(1, 2);
         final BigFraction b = BigFraction.of(1, 3);

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -183,18 +183,26 @@ class FractionTest {
 
     @Test
     void testIsOne() {
+        Assertions.assertTrue(Fraction.of(1, 2).one().isOne());
         Assertions.assertTrue(Fraction.of(1).isOne());
         Assertions.assertTrue(Fraction.of(1, 2).multiply(Fraction.of(2)).isOne());
         Fraction value = Fraction.of(17, 33);
         Assertions.assertTrue(value.multiply(value.reciprocal()).isOne());
+
+        Assertions.assertFalse(Fraction.of(3, 4).zero().isOne());
+        Assertions.assertFalse(Fraction.of(11, 12).isOne());
     }
 
     @Test
     void testIsZero() {
+        Assertions.assertTrue(Fraction.of(1, 1).zero().isZero());
         Assertions.assertTrue(Fraction.of(0, 4712).isZero());
         Assertions.assertTrue(Fraction.of(3).subtract(Fraction.of(3)).isZero());
         Fraction wide = Fraction.of(11, 1111111111);
         Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+
+        Assertions.assertFalse(Fraction.of(11, 12).one().isZero());
+        Assertions.assertFalse(Fraction.of(-3, 14).isZero());
     }
 
     @Test

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -198,8 +198,8 @@ class FractionTest {
         Assertions.assertTrue(Fraction.of(1, 1).zero().isZero());
         Assertions.assertTrue(Fraction.of(0, 4712).isZero());
         Assertions.assertTrue(Fraction.of(3).subtract(Fraction.of(3)).isZero());
-        Fraction wide = Fraction.of(11, 1111111111);
-        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+        Fraction value = Fraction.of(11, 1111111111);
+        Assertions.assertTrue(value.multiply(value.zero()).isZero());
 
         Assertions.assertFalse(Fraction.of(11, 12).one().isZero());
         Assertions.assertFalse(Fraction.of(-3, 14).isZero());

--- a/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
+++ b/commons-numbers-fraction/src/test/java/org/apache/commons/numbers/fraction/FractionTest.java
@@ -182,6 +182,22 @@ class FractionTest {
     }
 
     @Test
+    void testIsOne() {
+        Assertions.assertTrue(Fraction.of(1).isOne());
+        Assertions.assertTrue(Fraction.of(1, 2).multiply(Fraction.of(2)).isOne());
+        Fraction value = Fraction.of(17, 33);
+        Assertions.assertTrue(value.multiply(value.reciprocal()).isOne());
+    }
+
+    @Test
+    void testIsZero() {
+        Assertions.assertTrue(Fraction.of(0, 4712).isZero());
+        Assertions.assertTrue(Fraction.of(3).subtract(Fraction.of(3)).isZero());
+        Fraction wide = Fraction.of(11, 1111111111);
+        Assertions.assertTrue(wide.multiply(wide.zero()).isZero());
+    }
+
+    @Test
     void testCompareTo() {
         final Fraction a = Fraction.of(1, 2);
         final Fraction b = Fraction.of(1, 3);


### PR DESCRIPTION
All classes already implementing Addition and Multiplication got their specialized versions instead of just calling equals() on zero() or one() respectively to avoid potentially expensive operations, like BigFraction creating fresh copies of numerator and/or denominator if either is negative.

## Disclaimer
- I read the 'Contributing' page on commons.apache.org, but it mentions gitbox.apache.org, so I consider it a bit out of date and
- I prefer the simple statement in the README.md: we accept pull requests via GitHub :-)

## Rationale
While coding polynomial computations over differing fields with commons math3 where the field is a generic parameter in the implementation of monomials and polynomials, I coded the comparison with `zero` and `one` as `coefficient.getField().getZero().equals(coefficient)`. Looking a bit after performance with async-profiler I saw that the `equals()` required a non-negligible amount of CPU power, in particular for the BigFraction field.

I implemented this pull request, tried it in my code and the check on zero is not visible in the profiler output anymore.

## Alternatives
Instead of adding two new methods to interfaces it may be possible to improve the `equals()` methods of the classes implementing Addition and Multiplication to specifically watch out for comparison with these constants and invoke faster specialized code. Yet this seems like introducing somewhat nontrivial, even messy code. Whether this is preferable over an incompatible interface extension is hard to judge for an outsider.

## Note
This pull request does not increment the version number, which seems to be needed before a merge as I had to compile with 
```
mvn install -Dcommons.japicmp.breakBuildOnBinaryIncompatibleModifications=false
```
I rather leave the versioning to the experts.
